### PR TITLE
Remove unnecessary lines from remappings.txt

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,2 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-src/=src/
-test/=test/


### PR DESCRIPTION
I'm trying to include ring-buffer-lib and the twab-controller repos in my code, but with these two lines my code breaks because its trying to load everything from inside ring-buffer-lib.

```
Error (6275): Source "lib/ring-buffer-lib/src/YearnVaultV3.sol" not found: File not found. Searched the following locations: "/Users/bryan/code/alderson-dice/foundry".
ParserError: Source "lib/ring-buffer-lib/src/YearnVaultV3.sol" not found: File not found. Searched the following locations: "/Users/bryan/code/alderson-dice/foundry".
 --> test/GameToken.t.sol:6:1:
  |
6 | import {YearnVaultV3, YearnVaultV3Strategy} from "../src/YearnVaultV3.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
``` 

I ran `forge remappings` in this repo and it didn't write these lines for me, so I'm not sure why they are here.

Maybe `forge` should be smarter about this and we should open an issue there. but just removing these lines got things working for me